### PR TITLE
workflows: Bump super-linter version to 4.0.2

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: github/super-linter@v4.0.2
         env:
           # Don't check already existent files
           VALIDATE_ALL_CODEBASE: false


### PR DESCRIPTION
As per Teo's comment [1], super-linter didn't work with version 4, we had to bump it to an existing higher version.

[1] https://github.com/open-education-hub/operating-systems-oer/pull/10#issuecomment-1262268423