### PR TITLE
.gitignore: Ignore temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ dkms.conf
 
 # reveal-md slides output folder
 _site/
+
+# Temporary files
+*.swp
+*.swo
+*~


### PR DESCRIPTION
Ignore swap files (.swo, .swp) and temporary editor files (*~).